### PR TITLE
Add data/ and Slack wrapper for Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ If you want to search for products that don't have values listed here, you can u
 *Required*
 
 * `Product`: 
-  * PeopleSoft HCM: `21612`
+  * PeopleSoft HCM: `21858`
   * PeopleSoft FSCM: `21707`
   * PeopleSoft ELM: `21612`
   * PeopleSoft CS: `21591`

--- a/data/cm.yaml
+++ b/data/cm.yaml
@@ -1,0 +1,9 @@
+---
+descr:
+  cm: '%25CLOUD%25MANAGER%25'
+platform:
+  Linux: 226P
+product:
+  cm: '38378'
+release:
+  cm: '27001300090100'

--- a/data/pt.yaml
+++ b/data/pt.yaml
@@ -1,0 +1,13 @@
+---
+descr:
+  dpk: '%25Product%25Patch%25DPK'
+platform:
+  AIX: 212P
+  Linux: 226P
+  Windows: 233P
+product:
+  pt: '21917'
+release:
+  '8.58': '600000000115152'
+  '8.59': '600000000156683'
+  '8.60': '600000000171694'

--- a/data/pum.yaml
+++ b/data/pum.yaml
@@ -1,0 +1,15 @@
+---
+descr:
+  native: PEOPLESOFT%25UPDATE%25NATIVE+OS
+  virtual: PEOPLESOFT%25UPDATE%25VIRTUAL+BOX
+platform:
+  Linux: 226P
+product:
+  crm: '21523'
+  cs: '21591'
+  elm: '21612'
+  fscm: '21707'
+  hcm: '21858'
+  ih: '38378'
+release:
+  '9.2': '27001300090200'

--- a/patchBot.py
+++ b/patchBot.py
@@ -1,11 +1,9 @@
 import getpass
 import json
-import re
 import os
 import requests
 from bs4 import BeautifulSoup
 from requests.auth import HTTPBasicAuth
-# from http.cookiejar import MozillaCookieJar
 from cryptography.fernet import Fernet
 import logging
 
@@ -169,15 +167,19 @@ def set_slack_notification(webhook_url, message, username, channel):
         raise Exception(f"Failed to post to Slack: {e}")
 
 
-def find_latest_mos_patch(product, release, platform, description=None, notify=None, webhook_url=None, username=None, channel=None):
+def find_latest_mos_patch(product, release, platform, description=None, notify=None, webhook_url=None, username=None, channel=None, debug=False):
     username, password = get_my_oracle_support_credential()
     session = get_my_oracle_support_session(username, password)
+
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
 
     if session:
         new_patch, patch, descr = get_latest_patch_number(session, product, release, platform, description)
 
         if new_patch:
             message = f"*{descr}* is available: `{patch}`"
+            logging.info(f"  - New Patch: {patch}")
             # mosbot = f"/mos patch {patch}"
             if notify == "slack":
                 set_slack_notification(webhook_url, message, username, channel)
@@ -185,8 +187,6 @@ def find_latest_mos_patch(product, release, platform, description=None, notify=N
             elif notify == "teams":
                 # Future implementation for Microsoft Teams
                 pass
-            else:
-                print(message)
 
 
 

--- a/patchBot.py
+++ b/patchBot.py
@@ -130,7 +130,10 @@ def get_latest_patch_number(session, product, release, platform, description=Non
                 break
         
         # Find Patch Number
-        latest_patch = rows[1].find('td', class_='OraTableCellNumber').text.strip()
+        cell = None
+        cell = rows[1].find('td', class_='OraTableCellNumber')
+        if cell:
+            latest_patch = cell.text.strip()
 
         # Get Platform Friendly Name - Default is Platform Code
         friendly_name = None

--- a/slack.py
+++ b/slack.py
@@ -1,0 +1,24 @@
+# Load the patchBot functions
+from patchBot import find_latest_mos_patch
+import yaml
+import logging
+import argparse
+
+parser = argparse.ArgumentParser(description='Notify psadmin.io Community when new Patches have been found')
+parser.add_argument('-s', '--source')
+parser.add_argument('-t', '--token')
+args = parser.parse_args()
+
+DEBUG_LOGGING = True
+logging.basicConfig(level=logging.DEBUG if DEBUG_LOGGING else logging.INFO,
+                    format='[%(levelname)s] %(message)s')
+
+with open(f"data/{args.source}.yaml", 'r') as file:
+    patches = yaml.safe_load(file)
+
+for release_name, release_code in patches['release'].items():
+  for platform_name, platform_code in patches['platform'].items():
+    for product_name, product_code in patches['product'].items():
+      for descr_name, descr_code in patches['descr'].items():
+        logging.info(f"Searching for: {release_name} - {platform_name} - {product_name} - {descr_name}")
+        find_latest_mos_patch(product_code, release_code, platform_code, descr_code, "slack", f"https://hooks.slack.com/services/{args.token}", "patchbot", "#patch-notifications", False)


### PR DESCRIPTION
* `slack.py` can be used with Rundeck and takes parameters
* YAML files to make community additions to patchbot notifications via git commits